### PR TITLE
Update validateAndSanitizeStringWithArray for php8 support

### DIFF
--- a/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
+++ b/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
@@ -291,7 +291,7 @@ class SharedAccessSignatureHelper
         }
 
         Validate::isTrue(
-            strlen($input) == '',
+            strlen($input) == 0,
             sprintf(
                 Resources::STRING_NOT_WITH_GIVEN_COMBINATION,
                 implode(', ', $array)


### PR DESCRIPTION
This was the old code that is not working on php8.
Validate::isTrue(
            strlen($input) == '',
            sprintf(
                Resources::STRING_NOT_WITH_GIVEN_COMBINATION,
                implode(', ', $array)
            )
        );